### PR TITLE
Add Jest setup with sample test

### DIFF
--- a/__tests__/skills.test.js
+++ b/__tests__/skills.test.js
@@ -1,0 +1,5 @@
+const { calculateNumbers } = require('../skills');
+
+test('adds two numbers', () => {
+  expect(calculateNumbers(1, 2)).toBe(3);
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "skills-copilot-codespaces-vscode",
+  "version": "1.0.0",
+  "description": "<header>",
+  "main": "index.js",
+  "scripts": {
+    "test": "jest"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "devDependencies": {
+    "jest": "^29.0.0"
+  }
+}

--- a/skills.js
+++ b/skills.js
@@ -1,0 +1,4 @@
+function calculateNumbers(var1, var2) {
+  return var1 + var2;
+}
+module.exports = { calculateNumbers };


### PR DESCRIPTION
## Summary
- initialize `package.json` for Node project
- set up Jest for testing
- add `skills.js` with a simple function
- provide a Jest test for the function

## Testing
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_b_68645bb11c108328bf9c854b1a29d4f8