### PR TITLE
Fix typo in workflow comments

### DIFF
--- a/.github/workflows/1-copilot-extension.yml
+++ b/.github/workflows/1-copilot-extension.yml
@@ -21,7 +21,7 @@ permissions:
 
 jobs:
   # The purpose of this job is to output the current step number
-  # (retreived from the step file). This output variable can
+  # (retrieved from the step file). This output variable can
   # then be referenced in other jobs and used in conditional.
   # expressions.
   get_current_step:

--- a/.github/workflows/2-skills-javascript.yml
+++ b/.github/workflows/2-skills-javascript.yml
@@ -21,7 +21,7 @@ permissions:
 
 jobs:
   # The purpose of this job is to output the current step number
-  # (retreived from the step file). This output variable can
+  # (retrieved from the step file). This output variable can
   # then be referenced in other jobs and used in conditional
   # expressions.
   get_current_step:

--- a/.github/workflows/3-copilot-hub.yml
+++ b/.github/workflows/3-copilot-hub.yml
@@ -21,7 +21,7 @@ permissions:
 
 jobs:
   # The purpose of this job is to output the current step number
-  # (retreived from the step file). This output variable can
+  # (retrieved from the step file). This output variable can
   # then be referenced in other jobs and used in conditional
   # expressions.
   get_current_step:

--- a/.github/workflows/4-copilot-comment.yml
+++ b/.github/workflows/4-copilot-comment.yml
@@ -21,7 +21,7 @@ permissions:
 
 jobs:
   # The purpose of this job is to output the current step number
-  # (retreived from the step file). This output variable can
+  # (retrieved from the step file). This output variable can
   # then be referenced in other jobs and used in conditional
   # expressions.
   get_current_step:


### PR DESCRIPTION
## Summary
- fix the spelling of `retrieved` in four workflow comments

## Testing
- `grep -n retreived -R .github/workflows`

------
https://chatgpt.com/codex/tasks/task_b_6864ec8abc1c83288bbfdfdd5aa24028