### PR TITLE
Add Ghostframe task scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,4 @@
 .Trashes
 ehthumbs.db
 Thumbs.db
+ghostframe-tasks/__pycache__/

--- a/README.md
+++ b/README.md
@@ -83,6 +83,18 @@ Before you open up a codespace on a repository, you can create a development con
 
 **Wait about 60 seconds then refresh your repository landing page for the next step.**
 
+## Ghostframe tasks
+
+Utility scripts located in the `ghostframe-tasks` directory help manage text templates and issue tracking:
+
+| Script | Purpose |
+| ------ | ------- |
+| `convert_txt_to_json.py` | Convert `.txt` templates to `.json` files. |
+| `validate_templates.py` | Validate template JSON files and check required environment variables. |
+| `sync_linear_issues.py` | (Placeholder) Sync repository issues with Linear. |
+
+Run each script without arguments to display usage information.
+
 <footer>
 
 <!--

--- a/ghostframe-tasks/convert_txt_to_json.py
+++ b/ghostframe-tasks/convert_txt_to_json.py
@@ -1,0 +1,36 @@
+"""Utilities for converting text template files to JSON."""
+
+import json
+import sys
+from pathlib import Path
+
+
+def convert_directory(src_dir: Path, dest_dir: Path) -> None:
+    """Convert all ``.txt`` files in *src_dir* to JSON files under *dest_dir*."""
+
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    for txt_file in src_dir.glob("*.txt"):
+        json_file = dest_dir / f"{txt_file.stem}.json"
+        with txt_file.open("r", encoding="utf-8") as fh:
+            lines = [line.rstrip("\n") for line in fh]
+        with json_file.open("w", encoding="utf-8") as fh:
+            json.dump({"lines": lines}, fh, indent=2)
+
+
+def main() -> int:
+    """CLI entry point."""
+
+    if len(sys.argv) != 3:
+        print("Usage: convert_txt_to_json.py <src_dir> <dest_dir>")
+        return 1
+    src = Path(sys.argv[1])
+    dest = Path(sys.argv[2])
+    if not src.is_dir():
+        print(f"Source directory {src} does not exist", file=sys.stderr)
+        return 1
+    convert_directory(src, dest)
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/ghostframe-tasks/deploy_checkpoints.json
+++ b/ghostframe-tasks/deploy_checkpoints.json
@@ -1,0 +1,3 @@
+{
+  "checkpoints": []
+}

--- a/ghostframe-tasks/sync_linear_issues.py
+++ b/ghostframe-tasks/sync_linear_issues.py
@@ -1,0 +1,29 @@
+"""Sync GitHub issues with Linear."""
+
+import sys
+from pathlib import Path
+
+
+def sync_issues(repo_path: Path) -> None:
+    """Placeholder for future integration with the Linear API."""
+
+    print(f"Syncing issues for repository at {repo_path}")
+    # TODO: call Linear API
+
+
+def main() -> int:
+    """CLI entry point."""
+
+    if len(sys.argv) != 2:
+        print("Usage: sync_linear_issues.py <repo_path>")
+        return 1
+    repo_path = Path(sys.argv[1])
+    if not repo_path.is_dir():
+        print(f"Repository path {repo_path} not found", file=sys.stderr)
+        return 1
+    sync_issues(repo_path)
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/ghostframe-tasks/validate_templates.py
+++ b/ghostframe-tasks/validate_templates.py
@@ -1,0 +1,63 @@
+"""Utilities for validating text template JSON files."""
+
+import json
+import os
+import sys
+from pathlib import Path
+from jsonschema import ValidationError, validate
+
+TEMPLATE_SCHEMA = {
+    'type': 'object',
+    'properties': {
+        'lines': {
+            'type': 'array',
+            'items': {'type': 'string'}
+        }
+    },
+    'required': ['lines']
+}
+
+REQUIRED_ENV_VARS = ['API_KEY']
+
+
+def validate_env() -> bool:
+    """Ensure required environment variables are present."""
+
+    missing = [var for var in REQUIRED_ENV_VARS if not os.getenv(var)]
+    if missing:
+        print(f"Missing environment variables: {', '.join(missing)}", file=sys.stderr)
+        return False
+    return True
+
+
+def validate_templates(directory: Path) -> bool:
+    """Validate all JSON templates in *directory* against the schema."""
+
+    ok = True
+    for json_file in directory.glob("*.json"):
+        try:
+            data = json.loads(json_file.read_text())
+            validate(instance=data, schema=TEMPLATE_SCHEMA)
+        except (json.JSONDecodeError, ValidationError) as exc:
+            print(f"Validation failed for {json_file}: {exc}", file=sys.stderr)
+            ok = False
+    return ok
+
+
+def main() -> int:
+    """CLI entry point."""
+
+    if len(sys.argv) != 2:
+        print("Usage: validate_templates.py <directory>")
+        return 1
+    if not validate_env():
+        return 1
+    directory = Path(sys.argv[1])
+    if not directory.is_dir():
+        print(f"Directory {directory} not found", file=sys.stderr)
+        return 1
+    return 0 if validate_templates(directory) else 1
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- add Ghostframe utilities for converting text templates to JSON
- include template validation script with API key check
- add Linear issues sync placeholder
- track deployments in `deploy_checkpoints.json`
- ignore Python bytecode files
- document ghostframe scripts
- refactor scripts with docstrings

## Testing
- `npm test`
- `python3 -m py_compile ghostframe-tasks/*.py`


------
https://chatgpt.com/codex/tasks/task_b_6865141876d88328983a4919c4393fe0