### PR TITLE
Fix apostrophe style in step file

### DIFF
--- a/.github/steps/4-copilot-comment.md
+++ b/.github/steps/4-copilot-comment.md
@@ -10,7 +10,7 @@ _Nicely done utilizing the Copilot tab!_ :partying_face:
 
 You now have leveraged the Copilot quick tab auto-suggest as well as the Copilot hub to accept AI generated suggestions.
 
-Now lets see how you can leverage comments to generate Copilot suggestions!
+Now let's see how you can leverage comments to generate Copilot suggestions!
 
 ### :keyboard: Activity: Pull the latest code to the Codespace repo.
 


### PR DESCRIPTION
## Summary
- use an ASCII apostrophe for consistency in step 4 instructions

## Testing
- `npm test` *(fails: package.json missing)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_b_686509c1fb748328a900a2adcf62d7c2