### PR TITLE
Add requirements file

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ Utility scripts located in the `ghostframe-tasks` directory help manage text tem
 
 Run each script without arguments to display usage information.
 
+Install the required Python packages with `pip install -r requirements.txt`.
+
 <footer>
 
 <!--

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+jsonschema>=4.0


### PR DESCRIPTION
## Summary
- add a requirements.txt for Python utilities
- document installation command in the README

## Testing
- `npm test`
- `python ghostframe-tasks/validate_templates.py` *(fails: missing argument)*

------
https://chatgpt.com/codex/tasks/task_b_68657e08f5f08328bbad8f676f1e10d1