### PR TITLE
Update ghostframe docs to clarify stub

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,10 +91,10 @@ Utility scripts located in the `ghostframe-tasks` directory help manage text tem
 | ------ | ------- |
 | `convert_txt_to_json.py` | Convert `.txt` templates to `.json` files. |
 | `validate_templates.py` | Validate template JSON files and check required environment variables. |
-| `sync_linear_issues.py` | **Stub** — prints progress messages only and makes *no* network requests. It will create Linear tasks once integration is approved. |
+| `sync_linear_issues.py` | **Offline-only stub** — prints progress messages and never makes network requests. When integration is approved, it will create Linear tasks automatically. |
 
 > **Note**
-> `sync_linear_issues.py` is a stub. It never connects to the Linear API or makes network requests. Running it only echoes what it *would* do.
+> `sync_linear_issues.py` is strictly a stub. It never connects to the Linear API or performs network requests. Running it only echoes what it *would* do.
 
 Run each script without arguments to display usage information.
 

--- a/ghostframe-tasks/sync_linear_issues.py
+++ b/ghostframe-tasks/sync_linear_issues.py
@@ -1,7 +1,8 @@
-"""Stub for syncing GitHub issues with Linear.
+"""Offline-only stub for syncing GitHub issues with Linear.
 
-This script prints progress messages but never contacts the Linear API or makes
-any network requests. It is a placeholder for future integration once approved.
+This script merely prints progress messages; it never contacts the Linear API or
+makes network requests. Once integration is approved, it will create Linear
+tasks automatically.
 """
 
 import sys


### PR DESCRIPTION
## Summary
- update README to stress that `sync_linear_issues.py` doesn't contact the Linear API
- clarify stub status in the script

## Testing
- `npm test`
- `python -m compileall -q ghostframe-tasks`


------
https://chatgpt.com/codex/tasks/task_b_6865a34bb5308328bd4ec020030e0faf