### PR TITLE
Document Ghostframe env var

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Example environment configuration for Ghostframe tasks
+# Copy this file to `.env` and supply your API key.
+API_KEY=your-api-key-here

--- a/README.md
+++ b/README.md
@@ -95,6 +95,10 @@ Utility scripts located in the `ghostframe-tasks` directory help manage text tem
 
 Run each script without arguments to display usage information.
 
+### Prerequisites
+
+The `validate_templates.py` script requires an `API_KEY` environment variable. Copy `.env.example` to `.env` and add your key or export it directly in your shell before running the script.
+
 Templates should be organized in a `templates/` directory with text files
 under `templates/txt/`:
 


### PR DESCRIPTION
## Summary
- document the API_KEY prerequisite in the Ghostframe tasks section
- provide `.env.example` file

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6865c6b1fcc08328ba90fc91958f38c0