### PR TITLE
Update CLI usage strings and tests

### DIFF
--- a/ghostframe_tasks/convert_txt_to_json.py
+++ b/ghostframe_tasks/convert_txt_to_json.py
@@ -21,7 +21,7 @@ def main() -> int:
     """CLI entry point."""
 
     if len(sys.argv) != 3:
-        print("Usage: convert_txt_to_json.py <src_dir> <dest_dir>")
+        print("Usage: python -m ghostframe_tasks.convert_txt_to_json <src_dir> <dest_dir>")
         return 1
     src = Path(sys.argv[1])
     dest = Path(sys.argv[2])

--- a/ghostframe_tasks/sync_linear_issues.py
+++ b/ghostframe_tasks/sync_linear_issues.py
@@ -20,7 +20,7 @@ def main() -> int:
     """CLI entry point."""
 
     if len(sys.argv) != 2:
-        print("Usage: sync_linear_issues.py <repo_path>")
+        print("Usage: python -m ghostframe_tasks.sync_linear_issues <repo_path>")
         return 1
     repo_path = Path(sys.argv[1])
     if not repo_path.is_dir():

--- a/ghostframe_tasks/validate_templates.py
+++ b/ghostframe_tasks/validate_templates.py
@@ -48,7 +48,7 @@ def main() -> int:
     """CLI entry point."""
 
     if len(sys.argv) != 2:
-        print("Usage: validate_templates.py <directory>")
+        print("Usage: python -m ghostframe_tasks.validate_templates <directory>")
         return 1
     if not validate_env():
         return 1

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -1,5 +1,7 @@
 from pathlib import Path
 import json
+import subprocess
+import sys
 from ghostframe_tasks import convert_txt_to_json
 
 
@@ -14,3 +16,13 @@ def test_convert_directory(tmp_path: Path) -> None:
     assert json_file.exists()
     data = json.loads(json_file.read_text())
     assert data == {"lines": ["hello", "world"]}
+
+
+def test_convert_usage() -> None:
+    result = subprocess.run([
+        sys.executable,
+        "-m",
+        "ghostframe_tasks.convert_txt_to_json",
+    ], capture_output=True, text=True)
+    assert "python -m ghostframe_tasks.convert_txt_to_json" in result.stdout
+    assert result.returncode == 1

--- a/tests/test_sync.py
+++ b/tests/test_sync.py
@@ -1,4 +1,6 @@
 from pathlib import Path
+import subprocess
+import sys
 from ghostframe_tasks import sync_linear_issues
 
 
@@ -7,3 +9,13 @@ def test_sync_issues(capsys, tmp_path: Path) -> None:
     sync_linear_issues.sync_issues(repo)
     captured = capsys.readouterr()
     assert f"Syncing issues for repository at {repo}" in captured.out
+
+
+def test_sync_usage() -> None:
+    result = subprocess.run([
+        sys.executable,
+        "-m",
+        "ghostframe_tasks.sync_linear_issues",
+    ], capture_output=True, text=True)
+    assert "python -m ghostframe_tasks.sync_linear_issues" in result.stdout
+    assert result.returncode == 1

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -1,5 +1,7 @@
 import os
 from pathlib import Path
+import subprocess
+import sys
 from ghostframe_tasks import validate_templates
 
 
@@ -14,3 +16,14 @@ def test_validate_templates(tmp_path: Path, monkeypatch):
     json_file = json_dir / "example.json"
     json_file.write_text('{"lines": ["a", "b"]}')
     assert validate_templates.validate_templates(json_dir)
+
+
+def test_validate_usage(monkeypatch) -> None:
+    monkeypatch.delenv("API_KEY", raising=False)
+    result = subprocess.run([
+        sys.executable,
+        "-m",
+        "ghostframe_tasks.validate_templates",
+    ], capture_output=True, text=True)
+    assert "python -m ghostframe_tasks.validate_templates" in result.stdout
+    assert result.returncode == 1


### PR DESCRIPTION
## Summary
- update CLI usage messages to use module syntax
- add tests verifying the new usage text for CLI scripts

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6865eb1731ac83288b09c3c8b2cdaf3d