### PR TITLE
Add negative env and CLI tests

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,16 @@
+from ghostframe_tasks import convert_txt_to_json, validate_templates, sync_linear_issues
+
+
+def test_convert_cli_bad_args(monkeypatch):
+    monkeypatch.setattr('sys.argv', ['convert_txt_to_json.py'])
+    assert convert_txt_to_json.main() == 1
+
+
+def test_validate_cli_bad_args(monkeypatch):
+    monkeypatch.setattr('sys.argv', ['validate_templates.py'])
+    assert validate_templates.main() == 1
+
+
+def test_sync_cli_bad_args(monkeypatch):
+    monkeypatch.setattr('sys.argv', ['sync_linear_issues.py'])
+    assert sync_linear_issues.main() == 1

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -8,9 +8,28 @@ def test_validate_env(monkeypatch):
     assert validate_templates.validate_env()
 
 
+def test_validate_env_missing(monkeypatch, capsys):
+    """validate_env should fail when API_KEY is unset."""
+    monkeypatch.delenv("API_KEY", raising=False)
+    assert not validate_templates.validate_env()
+    captured = capsys.readouterr()
+    assert "Missing environment variables" in captured.err
+
+
 def test_validate_templates(tmp_path: Path, monkeypatch):
     monkeypatch.setenv("API_KEY", "dummy")
     json_dir = tmp_path
     json_file = json_dir / "example.json"
     json_file.write_text('{"lines": ["a", "b"]}')
     assert validate_templates.validate_templates(json_dir)
+
+
+def test_validate_templates_malformed(tmp_path: Path, monkeypatch, capsys):
+    """Malformed JSON should be reported and return False."""
+    monkeypatch.setenv("API_KEY", "dummy")
+    json_dir = tmp_path
+    bad_file = json_dir / "bad.json"
+    bad_file.write_text("{bad json}")
+    assert not validate_templates.validate_templates(json_dir)
+    captured = capsys.readouterr()
+    assert str(bad_file) in captured.err


### PR DESCRIPTION
## Summary
- ensure `validate_env` reports missing API key
- validate handling of malformed JSON
- test CLI entry points return error codes on bad input

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6865fb131cbc8328a48766612dd48852